### PR TITLE
Add tests for Registry action wrapping and sensitive data replacement

### DIFF
--- a/tests/test_action_model_utils.py
+++ b/tests/test_action_model_utils.py
@@ -1,0 +1,51 @@
+import pytest
+from pydantic import BaseModel, Field, create_model
+
+from browser_use.controller.registry.views import ActionModel, ActionRegistry, RegisteredAction
+
+def make_test_action_model(index_val=3):
+    # Dynamically create a minimal Pydantic param model with an index field
+    TestParams = create_model(
+        "TestParams",
+        index=(int, Field(default=index_val)),
+        __base__=BaseModel
+    )
+    # Dynamically create a subclass of ActionModel with a single action field
+    TestActionModel = create_model(
+        "TestActionModel",
+        test_action=(TestParams, ...),
+        __base__=ActionModel
+    )
+    return TestActionModel, TestParams
+
+def test_get_index_and_set_index():
+    TestActionModel, TestParams = make_test_action_model()
+    # Instantiate with index=3
+    model = TestActionModel(test_action=TestParams(index=3))
+    assert model.get_index() == 3
+
+    # Change index via set_index
+    model.set_index(7)
+    assert model.test_action.index == 7
+    assert model.get_index() == 7
+
+def test_action_registry_get_prompt_description():
+    # Minimal param model
+    TestParams = create_model(
+        "TestParams",
+        foo=(str, Field(default="bar")),
+        __base__=BaseModel
+    )
+    # Minimal RegisteredAction
+    reg_action = RegisteredAction(
+        name="foo_action",
+        description="Do foo things",
+        function=lambda: None,
+        param_model=TestParams
+    )
+    registry = ActionRegistry(actions={"foo_action": reg_action})
+    desc = registry.get_prompt_description()
+    assert isinstance(desc, str)
+    assert desc
+    assert "Do foo things" in desc
+    assert "foo_action" in desc

--- a/tests/test_registry_action_wrapper.py
+++ b/tests/test_registry_action_wrapper.py
@@ -1,0 +1,24 @@
+import pytest
+import inspect
+import asyncio
+
+from browser_use.controller.registry.service import Registry
+
+@pytest.fixture
+def registry():
+    return Registry()
+
+def test_action_wraps_sync_to_async(registry):
+    result_holder = {}
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    wrapped = registry.action(add)
+    assert inspect.iscoroutinefunction(wrapped)
+
+    # The wrapper should be awaitable and return correct result
+    async def run():
+        return await wrapped(2, 3)
+    result = asyncio.run(run())
+    assert result == 5

--- a/tests/test_sensitive_data_replacement.py
+++ b/tests/test_sensitive_data_replacement.py
@@ -1,0 +1,66 @@
+import pytest
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List
+from browser_use.controller.registry.service import Registry
+
+class DummyModel(BaseModel):
+    text: str
+
+class NestedModel(BaseModel):
+    meta: Dict[str, Any]
+    items: List[Any]
+
+@pytest.fixture
+def registry():
+    # The Registry class likely has a public interface, but for these tests we only need _replace_sensitive_data.
+    # We'll instantiate it directly. If Registry requires arguments, adjust as necessary.
+    return Registry()
+
+def test_simple_replacement(registry):
+    sensitive_data = {"password": "hunter2"}
+    model = DummyModel(text="my pass is <secret>password</secret>")
+    replaced = registry._replace_sensitive_data(model, sensitive_data)
+    assert isinstance(replaced, DummyModel)
+    assert replaced.text == "my pass is hunter2"
+
+def test_nested_structures(registry):
+    sensitive_data = {
+        "token": "XYZ123",
+        "email": "user@example.com"
+    }
+    model = NestedModel(
+        meta={
+            "auth": "<secret>token</secret>",
+            "profile": {
+                "email": "<secret>email</secret>"
+            }
+        },
+        items=[
+            "plain",
+            "<secret>token</secret>",
+            {"deep": "<secret>email</secret>"}
+        ]
+    )
+    replaced = registry._replace_sensitive_data(model, sensitive_data)
+    # Check replacements in nested dicts/lists
+    assert replaced.meta["auth"] == "XYZ123"
+    assert replaced.meta["profile"]["email"] == "user@example.com"
+    assert replaced.items[0] == "plain"
+    assert replaced.items[1] == "XYZ123"
+    assert replaced.items[2]["deep"] == "user@example.com"
+
+def test_missing_placeholder(registry):
+    sensitive_data = {}
+    model = DummyModel(text="keep <secret>notset</secret> as is")
+    replaced = registry._replace_sensitive_data(model, sensitive_data)
+    assert replaced.text == "keep <secret>notset</secret> as is"
+
+def test_return_type_and_integrity(registry):
+    sensitive_data = {"foo": "bar"}
+    model = DummyModel(text="no secrets here")
+    replaced = registry._replace_sensitive_data(model, sensitive_data)
+    assert isinstance(replaced, DummyModel)
+    # Unchanged values remain untouched
+    assert replaced.text == "no secrets here"
+    # The returned object should be a model of the same type and not a dict
+    assert type(replaced) is DummyModel

--- a/tests/test_time_execution_decorators.py
+++ b/tests/test_time_execution_decorators.py
@@ -1,0 +1,35 @@
+import time
+import pytest
+
+from browser_use.utils import time_execution_sync, time_execution_async
+
+def test_time_execution_sync_decorator(monkeypatch):
+    times = [0, 1]  # Will simulate 1s elapsed
+    def fake_time():
+        return times.pop(0)
+
+    monkeypatch.setattr(time, "time", fake_time)
+
+    @time_execution_sync("SYNC")
+    def add(x, y):
+        return x + y
+
+    result = add(2, 3)
+    assert result == 5
+    assert add.__name__ == "add"
+
+@pytest.mark.asyncio
+async def test_time_execution_async_decorator(monkeypatch):
+    times = [0, 1]  # Will simulate 1s elapsed
+    def fake_time():
+        return times.pop(0)
+
+    monkeypatch.setattr(time, "time", fake_time)
+
+    @time_execution_async("ASYNC")
+    async def multiply(x, y):
+        return x * y
+
+    result = await multiply(4, 5)
+    assert result == 20
+    assert multiply.__name__ == "multiply"


### PR DESCRIPTION
This pull request introduces two new test files to enhance the test coverage for the `Registry` class in the `browser_use.controller.registry.service` module.

1. **Test for Action Wrapping**: The `test_registry_action_wrapper.py` file includes a test to verify that synchronous functions can be correctly wrapped into asynchronous functions using the `action` method of the `Registry` class. It checks that the wrapped function is awaitable and returns the expected result.

2. **Test for Sensitive Data Replacement**: The `test_sensitive_data_replacement.py` file contains multiple tests for the `_replace_sensitive_data` method of the `Registry` class. It tests:
   - Simple replacement of sensitive data in a model.
   - Replacement in nested structures to ensure that sensitive data is correctly replaced in complex data types.
   - Handling of cases where placeholders are missing in the sensitive data.
   - Verification of the return type and integrity of the model after replacement.

These tests aim to ensure the robustness and reliability of the `Registry` class's functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [genie-use/6x05bfv8v1lo](http://localhost:3000/cosine-stg/genie-use/task/6x05bfv8v1lo)
Author: Cameron Nimmo
